### PR TITLE
chore: remove copyrights from meta error

### DIFF
--- a/parser/meta/error.go
+++ b/parser/meta/error.go
@@ -1,5 +1,3 @@
-// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
-
 package meta
 
 import "fmt"


### PR DESCRIPTION
remove copyrights from comment in `meta/error`